### PR TITLE
refactor(tooltip): use jotai to avoid excessive rerenders

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import FiltersLine from "../components/appUi/filtersLine";
 import Main from "../components/appUi/main";
-import { useVisibleCurrentsContext } from "../components/utils/contexts/currentsContext";
-import { FamilyType } from "../types/family";
-import { RepublicType } from "../types/republic";
-import { CurrentType } from "../types/current";
-import { EventType } from "../types/event";
+import {
+  currents,
+  events,
+  families,
+  republics
+} from "../components/utils/contexts/currentsContext";
 import SettingsLine from "../components/appUi/settingsLine";
-import republicsData from "../public/data/republics.json";
-import familiesData from "../public/data/currents.json";
-import eventsData from "../public/data/events.json";
 import InfosModal from "../components/appUi/infosModal";
 import { useTransitionsContext } from "../components/utils/contexts/transitionsContext";
 import { useCoalitionsContext } from "../components/utils/contexts/coalitionsContext";
 
 export default function HomePage() {
-  const [republics, setRepublics] = useState<RepublicType[] | null>(null);
-  const [currents, setCurrents] = useState<CurrentType[] | null>(null);
-  const [families, setFamilies] = useState<FamilyType[] | null>(null);
-  const [events, setEvents] = useState<EventType[] | null>(null);
-  const { visibleCurrents, setVisibleCurrents } = useVisibleCurrentsContext();
   const [eventVisibility, setEventVisibility] = useState(false);
   const [referenceSize, setReferenceSize] = useState(28);
   const [infosVisibility, setInfosVisibility] = useState(false);
@@ -29,18 +22,6 @@ export default function HomePage() {
     useTransitionsContext();
   const { coalitionsVisibility, setCoalitionsVisibility } =
     useCoalitionsContext();
-
-  // Fetch the data
-  useEffect(() => {
-    const currentsData = familiesData.families.flatMap(
-      (family: FamilyType) => family.currents
-    );
-    setRepublics(republicsData.republics);
-    setCurrents(currentsData);
-    setVisibleCurrents(currentsData);
-    setFamilies(familiesData.families);
-    setEvents(eventsData.events);
-  }, [setVisibleCurrents]); // Add republicsData, familiesData, eventsData to auto update when json files are updated (dev mode)
 
   return (
     <>

--- a/components/appUi/main.tsx
+++ b/components/appUi/main.tsx
@@ -6,7 +6,6 @@ import Chart from "../chart/chart";
 import { CurrentType } from "../../types/current";
 import { EventType } from "../../types/event";
 import { RepublicType } from "../../types/republic";
-import { TooltipProvider } from "../utils/contexts/tooltipContext";
 import { useDetailsContext } from "../utils/contexts/detailsContext";
 import { useEffect, useRef, useState } from "react";
 
@@ -49,15 +48,13 @@ export default function Main({
       >
         {/* Chart */}
         {republics && currents && events && (
-          <TooltipProvider>
-            <Chart
-              republics={republics}
-              currents={currents}
-              events={events}
-              eventsVisibility={eventsVisibility}
-              referenceSize={referenceSize}
-            />
-          </TooltipProvider>
+          <Chart
+            republics={republics}
+            currents={currents}
+            events={events}
+            eventsVisibility={eventsVisibility}
+            referenceSize={referenceSize}
+          />
         )}
 
         {selectedEntity && <EntityDetails />}

--- a/components/appUi/tooltip.tsx
+++ b/components/appUi/tooltip.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useRef, useState } from "react";
 import { TooltipContentType } from "../../types/tooltipContent";
-import { useTooltipContext } from "../utils/contexts/tooltipContext";
+import { tooltipContentAtom } from "../utils/contexts/tooltipContext";
 import EntityButton from "./entityButton";
 import Badge from "./badge";
 import PercentageButton from "./percentageButton";
 import { useDetailsContext } from "../utils/contexts/detailsContext";
+import { useAtomValue, useSetAtom } from "jotai";
 
 type Props = {
   chartWidth: number;
@@ -14,12 +15,24 @@ type Props = {
   tooltipContent: TooltipContentType;
 };
 
-export default function Tooltip({
+export default function Tooltip(props: Omit<Props, "tooltipContent">) {
+  const tooltipContent = useAtomValue(tooltipContentAtom);
+  if (!tooltipContent) return null;
+
+  return (
+    <TooltipContent
+      {...props}
+      tooltipContent={tooltipContent}
+    />
+  );
+}
+
+export function TooltipContent({
   chartWidth,
   axisLeftPosition,
   tooltipContent
 }: Props) {
-  const { setTooltipContent } = useTooltipContext();
+  const setTooltipContent = useSetAtom(tooltipContentAtom);
   const { setDetailsContent } = useDetailsContext();
   const { y, xStart, xEnd, legislature, party, coalitionDatas } =
     tooltipContent;

--- a/components/chart/chart.tsx
+++ b/components/chart/chart.tsx
@@ -3,7 +3,7 @@ import { EventType } from "../../types/event";
 import { RepublicType } from "../../types/republic";
 import Tooltip from "../appUi/tooltip";
 import { useDetailsContext } from "../utils/contexts/detailsContext";
-import { useTooltipContext } from "../utils/contexts/tooltipContext";
+import { tooltipContentAtom } from "../utils/contexts/tooltipContext";
 import { useTransitionsContext } from "../utils/contexts/transitionsContext";
 import useChartDimensions from "../utils/hooks/useChartDimensions";
 import Event from "./event";
@@ -11,6 +11,7 @@ import Republic from "./republic";
 import XAxis from "./xAxis";
 import YAxis from "./yAxis";
 import getDate from "../utils/getDate";
+import { useSetAtom } from "jotai";
 
 type Props = {
   republics: RepublicType[];
@@ -67,7 +68,7 @@ export default function Chart({
     : 400;
 
   // Get the tooltip party
-  const { tooltipContent, setTooltipContent } = useTooltipContext();
+  const setTooltipContent = useSetAtom(tooltipContentAtom);
 
   // Set the details content for events
   const { setDetailsContent } = useDetailsContext();
@@ -222,13 +223,10 @@ export default function Chart({
       </div>
 
       {/* Tooltip */}
-      {tooltipContent && (
-        <Tooltip
-          chartWidth={dimensions.width}
-          tooltipContent={tooltipContent}
-          axisLeftPosition={axisLeftPosition}
-        />
-      )}
+      <Tooltip
+        chartWidth={dimensions.width}
+        axisLeftPosition={axisLeftPosition}
+      />
     </div>
   );
 }

--- a/components/chart/legislature.tsx
+++ b/components/chart/legislature.tsx
@@ -3,7 +3,6 @@
 import PartyBar from "./partyBar";
 import { LegislatureType } from "../../types/legislature";
 import { ChartDimensions } from "../utils/hooks/useChartDimensions";
-import { useTooltipContext } from "../utils/contexts/tooltipContext";
 import { useVisibleCurrentsContext } from "../utils/contexts/currentsContext";
 import { CurrentType } from "../../types/current";
 import { motion } from "framer-motion";
@@ -11,6 +10,8 @@ import { useTransitionsContext } from "../utils/contexts/transitionsContext";
 import getDate from "../utils/getDate";
 import { useCoalitionsContext } from "../utils/contexts/coalitionsContext";
 import getYear from "../utils/getYear";
+import { useSetAtom } from "jotai";
+import { tooltipContentAtom } from "../utils/contexts/tooltipContext";
 
 type LegislatureProps = {
   leg: LegislatureType;
@@ -80,7 +81,7 @@ export default function Legislature({
     : null;
 
   // Set the hovered party
-  const { setTooltipContent } = useTooltipContext();
+  const setTooltipContent = useSetAtom(tooltipContentAtom);
 
   // Set the motion transition duration
   const transitionDuration = 0.5;

--- a/components/utils/contexts/currentsContext.tsx
+++ b/components/utils/contexts/currentsContext.tsx
@@ -2,7 +2,17 @@
 
 import { createContext, useContext, useState } from "react";
 import { CurrentType } from "../../../types/current";
+import republicsData from "../../../public/data/republics.json";
+import familiesData from "../../../public/data/currents.json";
+import eventsData from "../../../public/data/events.json";
+import { FamilyType } from "../../../types/family";
 
+export const republics = republicsData.republics;
+export const currents = familiesData.families.flatMap(
+  (family: FamilyType) => family.currents
+);
+export const families = familiesData.families;
+export const events = eventsData.events;
 interface VisibleCurrentsContextType {
   visibleCurrents: CurrentType[] | null;
   setVisibleCurrents: (visibleCurrents: CurrentType[]) => void;
@@ -30,7 +40,7 @@ export const VisibleCurrentsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [visibleCurrents, setVisibleCurrents] = useState(null);
+  const [visibleCurrents, setVisibleCurrents] = useState(currents);
 
   return (
     <VisibleCurrentsContext.Provider

--- a/components/utils/contexts/tooltipContext.tsx
+++ b/components/utils/contexts/tooltipContext.tsx
@@ -3,4 +3,6 @@
 import { atom } from "jotai";
 import { TooltipContentType } from "../../../types/tooltipContent";
 
-export const tooltipContentAtom = atom<TooltipContentType>(null as any);
+export const tooltipContentAtom = atom<TooltipContentType>(
+  null as TooltipContentType
+);

--- a/components/utils/contexts/tooltipContext.tsx
+++ b/components/utils/contexts/tooltipContext.tsx
@@ -1,42 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState } from "react";
+import { atom } from "jotai";
 import { TooltipContentType } from "../../../types/tooltipContent";
 
-interface TooltipContextType {
-  tooltipContent: TooltipContentType | null;
-  setTooltipContent: ({
-    xStart,
-    xEnd,
-    legislature,
-    party,
-    coalitionDatas
-  }: TooltipContentType) => void;
-}
-
-// Create context for tooltip
-const TooltipContext = createContext<TooltipContextType | undefined>(undefined);
-
-// Create a hook to use the tooltip context
-export const useTooltipContext = () => {
-  const context = useContext(TooltipContext);
-  if (!context) {
-    throw new Error("useTooltipContext must be used within a TooltipProvider");
-  }
-  return context;
-};
-
-// Create a provider for the tooltip context
-export const TooltipProvider = ({
-  children
-}: {
-  children: React.ReactNode;
-}) => {
-  const [tooltipContent, setTooltipContent] = useState(null);
-
-  return (
-    <TooltipContext.Provider value={{ tooltipContent, setTooltipContent }}>
-      {children}
-    </TooltipContext.Provider>
-  );
-};
+export const tooltipContentAtom = atom<TooltipContentType>(null as any);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@vercel/speed-insights": "^1.1.0",
         "d3": "^7.9.0",
         "framer-motion": "^11.11.9",
+        "jotai": "^2.11.1",
         "next": "^14.2.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1655,14 +1656,14 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.4",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
       "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2600,7 +2601,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3": {
@@ -5150,6 +5151,26 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.11.1.tgz",
+      "integrity": "sha512-41Su098mpHIX29hF/XOpDb0SqF6EES7+HXfrhuBqVSzRkxX48hD5i8nGsEewWZNAsBWJCTTmuz8M946Ih2PfcQ==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vercel/speed-insights": "^1.1.0",
     "d3": "^7.9.0",
     "framer-motion": "^11.11.9",
+    "jotai": "^2.11.1",
     "next": "^14.2.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
- Load data before first render to avoid using a useEffect
- Deleted TooltipContext to put it in a jotai atom, so the component setting it doesnt get rerendered